### PR TITLE
Update nav bar

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -44,5 +44,5 @@ img {
     width: 80%;
     height: 60%;
     display: block;
-    margin: 10px auto;
+    margin: 15px auto;
 }

--- a/css/styles.css
+++ b/css/styles.css
@@ -11,9 +11,38 @@ h2 {
     color: #e45f00;
 }
 
+.navBar{
+    width: 75%;
+    height: 60px;
+    margin: auto;
+}
+
+.navBar ul{
+    display: flex;
+    justify-content: space-evenly;
+    flex-wrap: nowrap;
+    align-items: center;
+    padding-inline-start: 0;
+    margin-block: 0;
+    height: 100%;
+}
+
+.navBar ul li{
+    padding: 10px;
+    display: block;
+}
+
+.navBar ul li a{
+    color: black;
+    text-decoration: none;
+    font-size: 25px;
+    font-family:'Times New Roman', Times, serif;
+}
+
+
 img {
     width: 80%;
     height: 60%;
     display: block;
-    margin: 0 auto;
+    margin: 10px auto;
 }

--- a/index.html
+++ b/index.html
@@ -8,6 +8,16 @@
     <body>
         <h1>Austin & Samantha</h1>
         <h2>June 24, 2024 - Perugia, Italy</h2>
+        <nav class="navBar">
+            <ul>
+                <li><a href="home.html">Home</a></li>
+                <li><a href="weddingdayagenda.html">Wedding Day Agenda</a></li>
+                <li><a href="gallery.html">Gallery</a></li>
+                <li><a href="RSVP.html">RSVP</a></li>
+                <li><a href="contactus.html">Contact Us</a></li>
+                <li><a href="FAQ.html">FAQ</a></li>
+            </ul>
+        </nav>
         <img id="home-image" src ="page-specific/home/AustinandSamEngagement-web_res.jpg" alt="Austin and Samantha engagement photo."/>
     </body>
 </html>


### PR DESCRIPTION
Added nav bar with the following headings: Home, Wedding Day Agenda, Gallery, RSVP, Contact Us, FAQ. (We can add/remove/change the heading names, I just put some generic ones). Links don't currently work as there is no destination pages created (didn't want to make the files in case we modify heading names).  

Updated img margin, so that when page is made really small, the nav bar does not overlap with image.

This is what it looks like now.

![navBar ScreenShot](https://github.com/AustinMcLean/AuSam/assets/59671674/dd3b34e2-d0fc-489d-83aa-b90d3222251f)

